### PR TITLE
Don't run pod coverage test in taint mode

### DIFF
--- a/xt/99_pod_coverage.t
+++ b/xt/99_pod_coverage.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
This can cause problems when testing on some older Perls, where
Pod::Coverage is unable to "require" some of the modules to find their
symbols, with no helpful diagnostics.

For example, I've seen this with Perl 5.10 and Perl 5.12:

  $ AUTHOR_TEST=1 ./Build test --test_files="xt/*.t"
  xt/99_critic.t ........ ok
  xt/99_pod.t ........... ok
  xt/99_pod_coverage.t .. 1/18
  #   Failed test 'Pod coverage on Module::CPANTS::Kwalitee::License'
  #   at /usr/share/perl5/vendor_perl/Test/Pod/Coverage.pm line 126.
  # Module::CPANTS::Kwalitee::License: requiring 'Module::CPANTS::Kwalitee::License' failed

  #   Failed test 'Pod coverage on Module::CPANTS::Kwalitee::Distname'
  #   at /usr/share/perl5/vendor_perl/Test/Pod/Coverage.pm line 126.
  # Module::CPANTS::Kwalitee::Distname: requiring 'Module::CPANTS::Kwalitee::Distname' failed

  #   Failed test 'Pod coverage on Module::CPANTS::Kwalitee::Signature'
  #   at /usr/share/perl5/vendor_perl/Test/Pod/Coverage.pm line 126.
  # Module::CPANTS::Kwalitee::Signature: requiring 'Module::CPANTS::Kwalitee::Signature' failed

  #   Failed test 'Pod coverage on Module::CPANTS::Kwalitee::Files'
  #   at /usr/share/perl5/vendor_perl/Test/Pod/Coverage.pm line 126.
  # Module::CPANTS::Kwalitee::Files: requiring 'Module::CPANTS::Kwalitee::Files' failed
  # Looks like you failed 4 tests of 18.
  xt/99_pod_coverage.t .. Dubious, test returned 4 (wstat 1024, 0x400)
  Failed 4/18 subtests
## Test Summary Report

xt/99_pod_coverage.t (Wstat: 1024 Tests: 18 Failed: 4)
  Failed tests:  15-18
  Non-zero exit status: 4
Files=3, Tests=56,  6 wallclock secs ( 0.03 usr  0.01 sys +  5.57 cusr  0.07 csys =  5.68 CPU)
Result: FAIL
Failed 1/3 test programs. 4/56 subtests failed.
