### PR TITLE
Support building with Test::More < 0.88

### DIFF
--- a/t/11_hash_random.t
+++ b/t/11_hash_random.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 2;
 
 for my $seed (qw(0xd8792d91 0x5be01872)) {
     local $ENV{PERL_HASH_SEED} = $seed;
@@ -12,4 +12,3 @@ for my $seed (qw(0xd8792d91 0x5be01872)) {
     my $content = qx/$cmd/;
     is($content, "4,0\n", "Slave forked script passed 3/3 checks with seed $seed");
 }
-done_testing;


### PR DESCRIPTION
done_testing was introduced in Test::More 0.88; by avoiding its use
and specifying a test count instead, the whole test suite can be run
using older versions of Test::More (I've verified that it works with
Test::More 0.47 for instance).

Alternatively, the Test::More version requirement should be
specified in the package metadata.
