### PR TITLE
RT#86504 - fix sort order of generators

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,14 @@
 
 Changes - Revision history for Module-CPANTS-Analyse
 
+=head2 0.93
+
+=over
+
+=item RT#86504 - fix sort order of Kwalitee generators (ether)
+
+=back
+
 =head2 0.90_02 2013-08-03
 
 =over

--- a/lib/Module/CPANTS/Kwalitee.pm
+++ b/lib/Module/CPANTS/Kwalitee.pm
@@ -19,9 +19,14 @@ sub new {
         ## no critic (ProhibitStringyEval)
         eval "require $gen";
         croak qq{cannot load $gen: $@} if $@;
-        $generators{$gen}=$gen->order;        
+        $generators{$gen}= [ $gen->order, $gen ];
     }
-    my @generators=sort { $generators{$a} <=> $generators{$b} } keys %generators;
+    # sort by 'order' first, then name
+    my @generators=sort {
+        $generators{$a}->[0] <=> $generators{$b}->[0]
+            ||
+        $generators{$a}->[1] cmp $generators{$b}->[1]
+    } keys %generators;
     $me->generators(\@generators);
     $me->_gencache({});
     return $me;


### PR DESCRIPTION
This is a recreation of https://github.com/daxim/Module-CPANTS-Analyse/pull/12

https://rt.cpan.org/Ticket/Display.html?id=86504

There is workaround code in Test::Kwalitee that I would like to remove, once this is in.
