### PR TITLE
fix use of $Test::Kwalitee::VERSION

### DIFF
--- a/lib/Module/CPANTS/Kwalitee/CpantsErrors.pm
+++ b/lib/Module/CPANTS/Kwalitee/CpantsErrors.pm
@@ -50,7 +50,7 @@ sub kwalitee_indicators {
             map {+{name => $_, code => sub {1}}}
             qw/extractable no_pod_errors
                has_test_pod has_test_pod_coverage/
-        ] if $Test::Kwalitee::VERSION < 1.08;
+        ] if version->parse(Test::Kwalitee->VERSION) < version->parse(1.08);
     }
 
     return [];


### PR DESCRIPTION
recreation of https://github.com/daxim/Module-CPANTS-Analyse/pull/14

as per #toolchain advice

```
15:35 <@ether> is there a preference between using $Foo::VERSION and Foo->VERSION, when needing to do version checks?
15:35 <@ether> and should they always return the same thing?
15:35  * ether flails trying to find any documentation of $VERSION at all
15:35 <@ether> (it's not perldoc perlvar)
15:36 <@ether> the method is documented in UNIVERSAL though
15:44 <@leont> You probably want to use Foo->VERSION, it's more likely to DWIM than $Foo::VERSION. In particular when vstrings come into play
15:52 <@leont> Whatever their faults may be, version objects are generally more sane than vstrings :-/
16:23 <@xdg> ether, Foo->VERSION($v) gives you properly parsed version.pm comparison of $Foo::VERSION and $v
16:23 <@xdg> But it's fatal.
16:24 <@xdg> So if fatal is OK, check verisons that way.  Otherwise, version->parse(Foo->VERSION) <=> version->parse($v) is the way to go
16:24 <@xdg> (theoretically Foo could override VERSION() to do something so you might as well respect that just in case.)
16:26 <@xdg> and there's no real documentation for $VERSION that I know of other than UNIVERSAL and vaguely perlfunc for "use"
16:26 <@xdg> (er, Foo->VERSION($v) DTRT for v5.10+ or version.pm loaded)
```
