### PR TITLE
Applies patch for RT 92257

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -21,6 +21,9 @@ my $build = Module::Build->new(
         'version'                   => '0.73',
         'File::Find::Rule::VCS'     => '0',
         'Software::License'         => '0.003',
+
+        # installs whole Software::License::CCpack
+        'Software::License::CC_BY_SA_3_0' => 0,
         'perl'                      => 5.006,
         'Set::Scalar'               => 0,
         'Text::Balanced'            => 0,


### PR DESCRIPTION
This adds a new module to recognize CC licenses.

This applies the patch provided in https://rt.cpan.org/Ticket/Display.html?id=92257

(the reason for Software::License::CC_BY_SA_3_0 and not Software::License::CCpack is because currently Software::License::CCpack is an unindexed .pod file, so I dunno if Build.PL would properly understand it, considering cpan doesn't find that name).
