### PR TITLE
Applies patch in RT#92247

### DIFF
--- a/lib/Module/CPANTS/Kwalitee/License.pm
+++ b/lib/Module/CPANTS/Kwalitee/License.pm
@@ -171,7 +171,8 @@ sub kwalitee_indicators{
             remedy=>q{Add =head1 LICENSE and the text of the license to the main module in your code.},
             code=>sub {
                 my $d = shift;
-                return $d->{license_in_pod} ? 1 : 0;
+                return $d->{license_in_pod} || $d->{unknown_license_texts}
+                    ? 1 : 0;
             },
             details=>sub {
                 my $d = shift;


### PR DESCRIPTION
Applies patch given in RT#92247 https://rt.cpan.org/Ticket/Display.html?id=92247#txn-1314069

The patch fixes the problem when the metric for "has LICENSE section in POD" fails when the LICENSE section references unknown license.
