### PR TITLE
hint for Dist::Zilla authors: Dist::Zilla::Plugin::MetaProvides

### DIFF
--- a/lib/Module/CPANTS/Kwalitee/MetaYML.pm
+++ b/lib/Module/CPANTS/Kwalitee/MetaYML.pm
@@ -137,7 +137,7 @@ sub kwalitee_indicators{
             name=>'metayml_has_provides',
             is_experimental=>1,
             error=>q{This distribution does not have a list of provided modules defined in META.yml.},
-            remedy=>q{Add all modules contained in this distribution to the META.yml field 'provides'. Module::Build does this automatically for you.},
+            remedy=>q{Add all modules contained in this distribution to the META.yml field 'provides'. Module::Build or Dist::Zilla::Plugin::MetaProvides do this automatically for you.},
             code=>sub { 
                 my $d=shift;
                 return 1 if $d->{meta_yml} && $d->{meta_yml}{provides};


### PR DESCRIPTION
metayml_has_provides:
Since Dist::Zilla::Plugin::MetaProvides is not in the Dist::Zilla core I think we should give authors a hint additional to Module::Build authors.
