### PR TITLE
MooseX::POE also provides strict and warnings

### DIFF
--- a/lib/Module/CPANTS/Kwalitee/Uses.pm
+++ b/lib/Module/CPANTS/Kwalitee/Uses.pm
@@ -28,6 +28,7 @@ our @STRICT_WARNINGS_EQUIV = qw(
   Moose Moose::Role Moose::Exporter
   Moose::Util::TypeConstraints Moose::Util::MetaRole
   MooseX::Declare MooseX::Role::Parameterized MooseX::Types
+  MooseX::POE
   Mouse Mouse::Role
   perl5 perl5i::1 perl5i::2 perl5i::latest
   Role::Tiny


### PR DESCRIPTION
This is part of my entry for the Pull Request Challenge in 2017 towards the dist semifor/twirc. This commit fixes a Kwalitee issue in one of the modules inside that dist, which is in fact not an issue at all.