### PR TITLE
Fix has_license_in_source_file for distributions that contain only a …

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Module-CPANTS-Analyse
 
+  - Fix has_license_in_source_file for distributions that contain only a
+    script under bin or scripts
+
 1.01 2019-08-08
   - Fixed not to set an error message when extracted nicely
     (spotted by Martin Becker++)

--- a/lib/Module/CPANTS/Kwalitee/License.pm
+++ b/lib/Module/CPANTS/Kwalitee/License.pm
@@ -41,7 +41,7 @@ sub analyse {
 
     # check pod
     my %licenses;
-    foreach my $file (grep { /\.(?:pm|pod|pl|PL)$/ } sort @$files ) {
+    foreach my $file (grep { /^(:?bin|scripts)|\.(?:pm|pod|pl|PL)$/ } sort @$files ) {
         next if $file =~ /(?:Makefile|Build)\.PL$/;
         my $path = catfile($distdir, $file);
         next unless -r $path; # skip if not readable


### PR DESCRIPTION
…script under bin or scripts