### PR TITLE
Use relative rather than absolute symlink in t/analyse/manifest.t

### DIFF
--- a/t/analyse/manifest.t
+++ b/t/analyse/manifest.t
@@ -57,7 +57,7 @@ test_distribution {
 MANIFEST
 EOF
 
-  eval { symlink "$dir/MANIFEST", "$dir/MANIFEST.lnk" };
+  eval { symlink "MANIFEST", "$dir/MANIFEST.lnk" };
   if ($@) {
     diag "symlink is not supported";
     return;
@@ -73,7 +73,7 @@ test_distribution {
 MANIFEST
 EOF
 
-  eval { symlink "$dir/MANIFEST", "$dir/MANIFEST.lnk" };
+  eval { symlink "MANIFEST", "$dir/MANIFEST.lnk" };
   if ($@) {
     diag "symlink is not supported";
     return;


### PR DESCRIPTION
`Archive::Tar` since version 3.08 will refuse to extract absolute symlinks unless `$Archive::Tar::INSECURE_EXTRACT_MODE` is set, leading to this test suite failure:
```
Symlink 'Module-CPANTS-Analyse-Test-0.01/MANIFEST.lnk' has absolute target. Not extracting under SECURE EXTRACT MODE at /usr/share/perl5/vendor_perl/Archive/Any/Lite.pm line 130.
t/analyse/manifest.t .....
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/14 subtests
```
This problem can be avoided by using relative symlinks:
  MANIFEST.lnk -> MANIFEST
rather than absolute symlinks:
  MANIFEST.lnk -> /path/to/tmpdir/MANIFEST
in the test.